### PR TITLE
feat: don't restrict club autocomplete

### DIFF
--- a/bot.toml.example
+++ b/bot.toml.example
@@ -5,22 +5,6 @@ log_level = "INFO"
 [guild]
 id = <the id of the server here>
 
-[guild.clubs.1]  # AE
-president_role_id = <role id>
-member_role_id = <role id>
-[guild.clubs.29]  # Club Welcome
-president_role_id = <role id>
-member_role_id = <role id>
-[guild.clubs.38]  # Troll Penché
-president_role_id = <role id>
-member_role_id = <role id>
-[guild.clubs.43]  # Reflex
-president_role_id = <role id>
-member_role_id = <role id>
-[guild.clubs.79]  # Cook'UT
-president_role_id = <role id>
-member_role_id = <role id>
-
 [sith_api]
 api_key = "<your sith api token here>"
 url = "https://ae.utbm.fr/"

--- a/src/commands/club.py
+++ b/src/commands/club.py
@@ -36,10 +36,9 @@ class ClubCog(commands.GroupCog, group_name="club"):
         self, _interaction: Interaction, current: str
     ) -> list[Choice]:
         """Autocompletion for clubs."""
-        return [
-            Choice(name=club.name, value=str(club.id))
-            for club in await self.club_service.search_club(current)
-        ]
+        clubs = await self.club_service.search_club(current)
+        clubs = clubs[:25]  # discord autocomplete can have at most 25 items
+        return [Choice(name=club.name, value=str(club.id)) for club in clubs]
 
     @app_commands.command(name="infos")
     @app_commands.autocomplete(club=autocomplete_club)

--- a/src/services/club.py
+++ b/src/services/club.py
@@ -6,8 +6,6 @@ from urllib.parse import urljoin
 import discord
 from discord import Embed
 
-from src.settings import Settings
-
 if TYPE_CHECKING:
     from src.client import ClubSchema, SimpleClubSchema, SithClient
     from src.main import AeBot
@@ -17,16 +15,13 @@ class ClubService:
     """Manage features directly related to clubs."""
 
     def __init__(self, client: SithClient, bot: AeBot):
-        self._config = Settings()
         self._client = client
         self._club_cache = {}
         self._bot = bot
 
     async def search_club(self, current: str) -> list[SimpleClubSchema]:
         clubs = await self._client.search_clubs(current)
-        if clubs is None:
-            return []
-        return [club for club in clubs if club.id in self._config.guild.clubs]
+        return clubs if clubs is not None else []
 
     async def get_club(self, club_id: int) -> ClubSchema | None:
         if club_id not in self._club_cache:

--- a/src/settings.py
+++ b/src/settings.py
@@ -17,14 +17,8 @@ class ApiConfig(BaseModel):
     api_key: SecretStr
 
 
-class ClubConfig(BaseModel):
-    president_role_id: int
-    member_role_id: int
-
-
 class GuildConfig(BaseModel):
     id: int
-    clubs: dict[int, ClubConfig]
 
 
 class BotConfig(BaseModel):


### PR DESCRIPTION
Mettre les ids des clubs dans la config, c'est trop rigide et trop restrictif.

Nouveau résultat : 
<img width="1048" height="632" alt="image" src="https://github.com/user-attachments/assets/62f468cc-0b3a-4fee-9171-fd8e375692b9" />

