### PR TITLE
fixes

### DIFF
--- a/src/commands/club.py
+++ b/src/commands/club.py
@@ -9,7 +9,7 @@ from discord.ext.commands import BadArgument
 
 from src.client import ClubSchema  # noqa TC001
 from src.db.models import Club
-from src.services.club import ClubExists, ClubService
+from src.services.club import ClubService
 from src.settings import Settings
 
 if TYPE_CHECKING:
@@ -122,10 +122,7 @@ class ClubCog(commands.GroupCog, group_name="club"):
         self, interaction: Interaction, club: Transform[ClubSchema, ClubTransformer]
     ):
         await interaction.response.defer(thinking=True)
-        try:
-            await self.club_service.create_club(club, interaction.guild)
-            await interaction.followup.send(f"Le club : {club.name} à été créé")
-        except ClubExists:
+        if Club.filter(Club.sith_id == club.id).exists():
             await interaction.followup.send(f"Le club : {club.name} existe déjà...")
         else:
             await self.club_service.create_club(club, interaction.guild)

--- a/src/services/club.py
+++ b/src/services/club.py
@@ -167,7 +167,8 @@ class ClubService:
             lambda c: c.name.endswith("[inactif]"),
             sorted(guild.categories, key=lambda c: c.position),
         )
-        await category.move(above=highest_inactive)
+        if highest_inactive:
+            await category.move(before=highest_inactive)
 
     async def stop_club(self, club: Club, guild: Guild):
         role_pres = utils.get(guild.roles, id=club.president_role_id)


### PR DESCRIPTION
- on ne vérifiait pas qu'il y a une club inactif. Donc essayait parfois de bouger une club au-dessus de rien, ce qui pouvait planter.
- Mauvais paramètre utilisé dans la méthode move.
- Une duplication de code (problème de rebase) faisait qu'un club pouvait voir ses salons recréés, même dans des cas où la commande aurait dû échouer